### PR TITLE
remove mkdir

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ ImageMagick, PhantomJS etc, it's more specialised towards Phoenix apps.
 FROM marvellousmutants/phoenix:latest
 
 # Create working directory
-RUN mkdir /app
 WORKDIR /app
 
 # Get your app and add it to the working directory


### PR DESCRIPTION
From the doc https://docs.docker.com/engine/reference/builder/#/workdir :

> If the WORKDIR doesn’t exist, it will be created even if it’s not used in any subsequent Dockerfile instruction.
